### PR TITLE
httpStatusCodes

### DIFF
--- a/src/track/track.controller.ts
+++ b/src/track/track.controller.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import {
   Body,
   Controller,
@@ -6,6 +7,9 @@ import {
   Post,
   Delete,
   Put,
+  HttpStatus,
+  Res,
+  HttpCode,
 } from '@nestjs/common';
 import { TrackService } from './track.service';
 import { iTrack } from './track.interface';
@@ -19,8 +23,21 @@ export class TrackController {
   }
 
   @Get(':id')
-  getTrackById(@Param('id') id: string): Promise<iTrack> {
-    return this.trackService.getTrackById(id);
+  async getTrackById(@Res() response, @Param('id') id: string): Promise<any> {
+    try {
+      const responseFromService = await this.trackService.getTrackById(id);
+      if (Object.keys(responseFromService).length) {
+        return response.status(HttpStatus.OK).json(responseFromService);
+      } else {
+        return response
+          .status(HttpStatus.NOT_FOUND)
+          .json({ error: 'track no existe' });
+      }
+    } catch (error) {
+      return response
+        .status(HttpStatus.NOT_FOUND)
+        .json({ error: 'el id de ese track no existe' });
+    }
   }
 
   @Post()
@@ -34,6 +51,7 @@ export class TrackController {
   }
 
   @Put(':id')
+  @HttpCode(204)
   updateTrackById(
     @Param('id') id: string,
     @Body() body: iTrack,


### PR DESCRIPTION
Aprendimos a lanzar códigos de respuesta con el decorador HttpCode. También procesamos en el controlador el caso en el que no se encuentra un recurso para que el código de respuesta sea 404 Not Found. Para ellos utilizamos el decorador Res. También vimos que existe un enum llamado HttpStatus con los mensajes de respuesta estándar.